### PR TITLE
fix: correct H1 title to match spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Run TestCafe Tests with LambdaTest Reporter on TestMu AI (Formerly LambdaTest)
+# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -19,7 +19,7 @@ With TestMu AI (Formerly LambdaTest), you can run TestCafe tests across real bro
 
 - Node.js (LTS version recommended)
 - TestCafe installed globally or as a project dependency
-- A TestMu AI (Formerly LambdaTest) account — sign up here
+- A TestMu AI account — [sign up here](https://www.testmuai.com/register/)
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run TestCafe Reporter on TestMu AI (Formerly LambdaTest)
+﻿# Run TestCafe Tests with LambdaTest Reporter on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,9 +17,9 @@ With TestMu AI (Formerly LambdaTest), you can run TestCafe tests across real bro
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (LTS version recommended)
-- [TestCafe](https://devexpress.github.io/testcafe/) installed globally or as a project dependency
-- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+- Node.js (LTS version recommended)
+- TestCafe installed globally or as a project dependency
+- A TestMu AI (Formerly LambdaTest) account — sign up here
 
 ### Setup
 


### PR DESCRIPTION
## Summary

- Corrects H1 title to `# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)` per spec (was "Run TestCafe Tests with LambdaTest Reporter on...")
- Prerequisites section: restored sign-up link for TestMu AI account, removed hyperlinks from Node.js and TestCafe entries (link-stripping pass)
- All brand substitutions in descriptive sections already applied; boilerplate sections left unchanged per spec
- URLs, env var names (LT_USERNAME, LT_ACCESS_KEY), code blocks, and package names left unchanged

## Test plan

- [ ] Verify H1 reads `# Run TestCafe Tests on TestMu AI (Formerly LambdaTest)`
- [ ] Verify no stray "LambdaTest" brand references remain outside protected boilerplate sections
- [ ] Verify code blocks are untouched
- [ ] Verify all URLs still resolve correctly